### PR TITLE
Fix module order

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -67,7 +67,7 @@ class ImageMagicConan(ConanFile):
 
     @property
     def _modules(self):
-        return ['MagickCore', 'MagickWand', 'Magick++']
+        return ['Magick++', 'MagickWand', 'MagickCore']
 
     def config_options(self):
         if self.settings.os == 'Windows':


### PR DESCRIPTION
The previously used order would cause static linking to fail with undefined references when attempting to use conan-imagemagick as a requirement for other packages.

This change probably needs to be applied to the other branches, too.
